### PR TITLE
Build Linux binaries via Docker container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
-
+docker-slim
+docker-slim-sensor

--- a/Dockerfile-build
+++ b/Dockerfile-build
@@ -1,0 +1,10 @@
+FROM golang:latest
+RUN mkdir -p /go/src/github.com/cloudimmunity/docker-slim
+ADD . /go/src/github.com/cloudimmunity/docker-slim
+WORKDIR /go/src/github.com/cloudimmunity/docker-slim/apps/docker-slim
+RUN go get
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o docker-slim .
+
+WORKDIR /go/src/github.com/cloudimmunity/docker-slim/apps/docker-slim-sensor
+RUN go get
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o docker-slim-sensor .

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+NAME = cloudimmunity/docker-slim
+INSTANCE = docker-slim
+
+.PHONY: default build 
+
+default: build
+
+build:
+	docker rm -f $(INSTANCE); true
+	docker build -f Dockerfile-build -t $(NAME)-build .
+	docker create --name $(INSTANCE) $(NAME)-build
+	docker cp $(INSTANCE):/go/src/github.com/$(NAME)/apps/docker-slim/docker-slim $(shell pwd)/docker-slim
+	docker cp $(INSTANCE):/go/src/github.com/$(NAME)/apps/docker-slim-sensor/docker-slim-sensor $(shell pwd)/docker-slim-sensor
+	docker rm $(INSTANCE)
+


### PR DESCRIPTION
Use a Golang container to build the two binaries for Linux. After building Make will extract the binaries from a Docker container and place them in the root directory.

To build run `make`