### PR TITLE
Sending payload in http probe

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,8 @@ Commands in `probeCmds.json`:
    {
      "protocol": "http",
      "method": "POST",
-     "resource": "/submit2"
+     "resource": "/submit2",
+     "body": "key=value"
    }
   ]
 }

--- a/master/inspectors/container/probes/http/custom_probe.go
+++ b/master/inspectors/container/probes/http/custom_probe.go
@@ -61,6 +61,7 @@ func (p *HttpProbe) Start() {
 					res, err := goreq.Request{
 						Method:  cmd.Method,
 						Uri:     addr,
+						Body:    cmd.Body,
 						Timeout: 5 * time.Second,
 						//ShowDebug: true,
 					}.Do()


### PR DESCRIPTION
Some fancy apps need to receive a proper body to do what they do. This adds a single line that is needed to make including a payload in a probe possible (by adding a "body" key in the commands file, with a raw string of what is to be sent within the request).